### PR TITLE
Implement brace matcher, commenter, folding builder(for match { ... } else { ... }, "alternatives", extern {...} and enum {...}),  and quote handler

### DIFF
--- a/src/main/grammars/LalrpopParser.bnf
+++ b/src/main/grammars/LalrpopParser.bnf
@@ -69,7 +69,10 @@ nonterminal_ref ::= ID {
     mixin = "com.mdrobnak.lalrpop.psi.ext.LpNonterminalRefMixin"
 }
 
-alternatives ::= alternative SEMICOLON | LBRACE <<comma alternative>> RBRACE SEMICOLON?
+alternatives ::= alternative SEMICOLON | LBRACE <<comma alternative>> RBRACE SEMICOLON? {
+    implements = "com.mdrobnak.lalrpop.psi.LpFoldable"
+    mixin = "com.mdrobnak.lalrpop.psi.ext.LpAlternativesMixin"
+}
 
 alternative ::= symbol+ (IF cond)? action?
     | (IF cond)? action
@@ -116,9 +119,15 @@ type_ref ::= LPAREN <<comma type_ref>> RPAREN
 type_ref_or_lifetime ::= type_ref | LIFETIME
 
 extern_token ::= EXTERN LBRACE associated_type* enum_token associated_type* RBRACE
-    | EXTERN LBRACE associated_type* RBRACE
+    | EXTERN LBRACE associated_type* RBRACE {
+    implements = "com.mdrobnak.lalrpop.psi.LpFoldable"
+    mixin = "com.mdrobnak.lalrpop.psi.ext.LpExternTokenMixin"
+}
 
-match_token ::= MATCH LBRACE match_contents RBRACE (ELSE LBRACE match_contents RBRACE)*
+match_token ::= MATCH LBRACE match_contents RBRACE (ELSE LBRACE match_contents RBRACE)* {
+    implements = "com.mdrobnak.lalrpop.psi.LpFoldable"
+    mixin = "com.mdrobnak.lalrpop.psi.ext.LpMatchTokenMixin"
+}
 
 match_contents ::= <<comma match_item>>
 
@@ -128,7 +137,10 @@ match_item ::= UNDERSCORE
 
 match_symbol ::= quoted_literal
 
-enum_token ::= ENUM type_ref LBRACE <<comma conversion>> RBRACE
+enum_token ::= ENUM type_ref LBRACE <<comma conversion>> RBRACE {
+    implements = "com.mdrobnak.lalrpop.psi.LpFoldable"
+    mixin = "com.mdrobnak.lalrpop.psi.ext.LpEnumTokenMixin"
+}
 
 associated_type ::= TYPE ID EQUALS type_ref SEMICOLON
 

--- a/src/main/kotlin/com/mdrobnak/lalrpop/LpBraceMatcher.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/LpBraceMatcher.kt
@@ -23,11 +23,16 @@ object LpBraceMatcher : PairedBraceMatcher {
     }
 
     override fun getCodeConstructStart(file: PsiFile, openingBraceOffset: Int): Int {
-        for (element in file.elementsAtOffsetUp(openingBraceOffset)) {
-            when (element.first) {
-                is LpGrammarItem, is LpEnumToken -> return element.first.startOffset
+        // walk up the tree and look for a LpGrammarItem or an LpEnumToken
+        // which cover the only constructs(aside action code) in a lalrpop file that may have braces.
+        var element = file.findElementAt(openingBraceOffset)
+        while (element != null) {
+            when (element) {
+                is LpGrammarItem, is LpEnumToken -> return element.startOffset
             }
+
+            element = element.parent
         }
-        return 0
+        return openingBraceOffset
     }
 }

--- a/src/main/kotlin/com/mdrobnak/lalrpop/LpBraceMatcher.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/LpBraceMatcher.kt
@@ -1,0 +1,33 @@
+package com.mdrobnak.lalrpop
+
+import com.intellij.lang.BracePair
+import com.intellij.lang.PairedBraceMatcher
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.elementsAtOffsetUp
+import com.mdrobnak.lalrpop.psi.*
+import org.rust.lang.core.psi.ext.startOffset
+
+object LpBraceMatcher : PairedBraceMatcher {
+    val pairsArray = arrayOf(
+        BracePair(LpElementTypes.LBRACE, LpElementTypes.RBRACE, true),
+        BracePair(LpElementTypes.LBRACKET, LpElementTypes.RBRACKET, false),
+        BracePair(LpElementTypes.LPAREN, LpElementTypes.RPAREN, false),
+        BracePair(LpElementTypes.LESSTHAN, LpElementTypes.GREATERTHAN, false),
+    )
+
+    override fun getPairs(): Array<BracePair> = pairsArray
+
+    override fun isPairedBracesAllowedBeforeType(lbraceType: IElementType, contextType: IElementType?): Boolean {
+        return true
+    }
+
+    override fun getCodeConstructStart(file: PsiFile, openingBraceOffset: Int): Int {
+        for (element in file.elementsAtOffsetUp(openingBraceOffset)) {
+            when (element.first) {
+                is LpGrammarItem, is LpEnumToken -> return element.first.startOffset
+            }
+        }
+        return 0
+    }
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/LpCommenter.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/LpCommenter.kt
@@ -1,0 +1,16 @@
+package com.mdrobnak.lalrpop
+
+import com.intellij.lang.Commenter
+
+object LpCommenter : Commenter {
+    override fun getLineCommentPrefix(): String? = "//"
+
+    override fun getBlockCommentPrefix(): String? = "/*"
+
+    override fun getBlockCommentSuffix(): String? = "*/"
+
+    // TODO: not sure what "commented beginning/end of a block comment" mean so might want to change?
+    override fun getCommentedBlockCommentPrefix(): String? = null
+
+    override fun getCommentedBlockCommentSuffix(): String? = null
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/LpFoldingBuilder.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/LpFoldingBuilder.kt
@@ -13,8 +13,8 @@ import com.mdrobnak.lalrpop.psi.LpFoldable
 object LpFoldingBuilder : FoldingBuilderEx(), DumbAware {
     override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
         return PsiTreeUtil.findChildrenOfType(root, LpFoldable::class.java).stream()
-            .map { it.getFoldRegions(document, quick) }
-            .flatMap { (List<FoldingDescriptor>::stream)(it) }.toArray { arrayOfNulls<FoldingDescriptor>(it) }
+            .flatMap { it.getFoldRegions(document, quick).stream() }
+            .toArray { arrayOfNulls(it) }
     }
 
     override fun getPlaceholderText(node: ASTNode): String? = when (val nodePsi = node.psi) {

--- a/src/main/kotlin/com/mdrobnak/lalrpop/LpFoldingBuilder.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/LpFoldingBuilder.kt
@@ -1,0 +1,29 @@
+package com.mdrobnak.lalrpop
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.mdrobnak.lalrpop.psi.LpFoldable
+
+
+object LpFoldingBuilder : FoldingBuilderEx(), DumbAware {
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        return PsiTreeUtil.findChildrenOfType(root, LpFoldable::class.java).stream()
+            .map { it.getFoldRegions(document, quick) }
+            .flatMap { (List<FoldingDescriptor>::stream)(it) }.toArray { arrayOfNulls<FoldingDescriptor>(it) }
+    }
+
+    override fun getPlaceholderText(node: ASTNode): String? = when (val nodePsi = node.psi) {
+        is LpFoldable -> nodePsi.getFoldReplacement()
+        else -> null
+    }
+
+    override fun isCollapsedByDefault(node: ASTNode): Boolean = when (val nodePsi = node.psi) {
+        is LpFoldable -> nodePsi.getFoldCollapsedByDefault()
+        else -> false
+    }
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/LpQuoteHandler.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/LpQuoteHandler.kt
@@ -1,0 +1,6 @@
+package com.mdrobnak.lalrpop
+
+import com.intellij.codeInsight.editorActions.SimpleTokenSetQuoteHandler
+import com.mdrobnak.lalrpop.psi.LpElementTypes
+
+class LpQuoteHandler : SimpleTokenSetQuoteHandler(LpElementTypes.STR_LITERAL)

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/LpFoldable.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/LpFoldable.kt
@@ -1,0 +1,11 @@
+package com.mdrobnak.lalrpop.psi
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+interface LpFoldable : PsiElement {
+    fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor>
+    fun getFoldReplacement(): String?
+    fun getFoldCollapsedByDefault(): Boolean
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpAlternatives.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpAlternatives.kt
@@ -1,0 +1,33 @@
+package com.mdrobnak.lalrpop.psi.ext
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.mdrobnak.lalrpop.psi.LpAlternatives
+import com.mdrobnak.lalrpop.psi.LpElementTypes
+import org.rust.lang.core.psi.ext.childrenWithLeaves
+import org.rust.lang.core.psi.ext.elementType
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.lang.core.psi.ext.startOffset
+
+abstract class LpAlternativesMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpAlternatives {
+    override fun getFoldRegions(document: Document, quick: Boolean) =
+        if (this.childrenWithLeaves.first().elementType == LpElementTypes.LBRACE) {
+            listOf(
+                FoldingDescriptor(
+                    this.node,
+                    TextRange(
+                        this.startOffset,
+                        this.childrenWithLeaves.last { it.elementType == LpElementTypes.RBRACE }.endOffset
+                    )
+                )
+            )
+        } else {
+            listOf()
+        }
+
+    override fun getFoldReplacement(): String? = "{ ... }"
+    override fun getFoldCollapsedByDefault(): Boolean = false
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpAlternatives.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpAlternatives.kt
@@ -7,26 +7,14 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.mdrobnak.lalrpop.psi.LpAlternatives
 import com.mdrobnak.lalrpop.psi.LpElementTypes
+import com.mdrobnak.lalrpop.psi.util.braceMatcherFoldDescriptors
 import org.rust.lang.core.psi.ext.childrenWithLeaves
 import org.rust.lang.core.psi.ext.elementType
 import org.rust.lang.core.psi.ext.endOffset
 import org.rust.lang.core.psi.ext.startOffset
 
 abstract class LpAlternativesMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpAlternatives {
-    override fun getFoldRegions(document: Document, quick: Boolean) =
-        if (this.childrenWithLeaves.first().elementType == LpElementTypes.LBRACE) {
-            listOf(
-                FoldingDescriptor(
-                    this.node,
-                    TextRange(
-                        this.startOffset,
-                        this.childrenWithLeaves.last { it.elementType == LpElementTypes.RBRACE }.endOffset
-                    )
-                )
-            )
-        } else {
-            listOf()
-        }
+    override fun getFoldRegions(document: Document, quick: Boolean) = braceMatcherFoldDescriptors(this)
 
     override fun getFoldReplacement(): String? = "{ ... }"
     override fun getFoldCollapsedByDefault(): Boolean = false

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpEnumToken.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpEnumToken.kt
@@ -5,11 +5,11 @@ import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.mdrobnak.lalrpop.psi.LpEnumToken
-import com.mdrobnak.lalrpop.psi.util.depthOneBraceMatcherFoldDescriptors
+import com.mdrobnak.lalrpop.psi.util.braceMatcherFoldDescriptors
 
 abstract class LpEnumTokenMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpEnumToken {
     override fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor> =
-        depthOneBraceMatcherFoldDescriptors(this, document, quick)
+        braceMatcherFoldDescriptors(this)
 
     override fun getFoldReplacement(): String? = "{ ... }"
     override fun getFoldCollapsedByDefault(): Boolean = false

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpEnumToken.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpEnumToken.kt
@@ -1,0 +1,16 @@
+package com.mdrobnak.lalrpop.psi.ext
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.mdrobnak.lalrpop.psi.LpEnumToken
+import com.mdrobnak.lalrpop.psi.util.depthOneBraceMatcherFoldDescriptors
+
+abstract class LpEnumTokenMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpEnumToken {
+    override fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor> =
+        depthOneBraceMatcherFoldDescriptors(this, document, quick)
+
+    override fun getFoldReplacement(): String? = "{ ... }"
+    override fun getFoldCollapsedByDefault(): Boolean = false
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpExternToken.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpExternToken.kt
@@ -1,0 +1,16 @@
+package com.mdrobnak.lalrpop.psi.ext
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.mdrobnak.lalrpop.psi.LpExternToken
+import com.mdrobnak.lalrpop.psi.util.depthOneBraceMatcherFoldDescriptors
+
+abstract class LpExternTokenMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpExternToken {
+    override fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor> =
+        depthOneBraceMatcherFoldDescriptors(this, document, quick)
+
+    override fun getFoldReplacement(): String? = "{ ... }"
+    override fun getFoldCollapsedByDefault(): Boolean = false
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpExternToken.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpExternToken.kt
@@ -5,11 +5,11 @@ import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.mdrobnak.lalrpop.psi.LpExternToken
-import com.mdrobnak.lalrpop.psi.util.depthOneBraceMatcherFoldDescriptors
+import com.mdrobnak.lalrpop.psi.util.braceMatcherFoldDescriptors
 
 abstract class LpExternTokenMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpExternToken {
     override fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor> =
-        depthOneBraceMatcherFoldDescriptors(this, document, quick)
+        braceMatcherFoldDescriptors(this)
 
     override fun getFoldReplacement(): String? = "{ ... }"
     override fun getFoldCollapsedByDefault(): Boolean = false

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpMatchToken.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpMatchToken.kt
@@ -5,11 +5,11 @@ import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.mdrobnak.lalrpop.psi.LpMatchToken
-import com.mdrobnak.lalrpop.psi.util.depthOneBraceMatcherFoldDescriptors
+import com.mdrobnak.lalrpop.psi.util.braceMatcherFoldDescriptors
 
 abstract class LpMatchTokenMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpMatchToken {
     override fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor> =
-        depthOneBraceMatcherFoldDescriptors(this, document, quick)
+        braceMatcherFoldDescriptors(this)
 
     override fun getFoldReplacement(): String? = "{ ... }"
     override fun getFoldCollapsedByDefault(): Boolean = false

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpMatchToken.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/ext/LpMatchToken.kt
@@ -1,0 +1,16 @@
+package com.mdrobnak.lalrpop.psi.ext
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.mdrobnak.lalrpop.psi.LpMatchToken
+import com.mdrobnak.lalrpop.psi.util.depthOneBraceMatcherFoldDescriptors
+
+abstract class LpMatchTokenMixin(node: ASTNode) : ASTWrapperPsiElement(node), LpMatchToken {
+    override fun getFoldRegions(document: Document, quick: Boolean): List<FoldingDescriptor> =
+        depthOneBraceMatcherFoldDescriptors(this, document, quick)
+
+    override fun getFoldReplacement(): String? = "{ ... }"
+    override fun getFoldCollapsedByDefault(): Boolean = false
+}

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/util/LpPsiFoldUtil.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/util/LpPsiFoldUtil.kt
@@ -1,7 +1,6 @@
 package com.mdrobnak.lalrpop.psi.util
 
 import com.intellij.lang.folding.FoldingDescriptor
-import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
@@ -9,17 +8,26 @@ import com.mdrobnak.lalrpop.psi.LpElementTypes
 import org.rust.lang.core.psi.ext.childrenWithLeaves
 import org.rust.lang.core.psi.ext.endOffset
 import org.rust.lang.core.psi.ext.startOffset
+import java.util.*
 
-fun depthOneBraceMatcherFoldDescriptors(element: PsiElement, document: Document, quick: Boolean): List<FoldingDescriptor> {
+/**
+ * For a given PSI element, returns a list of folding descriptors for pairs of braces.
+ * The ranges also contain the braces themselves.
+ */
+fun braceMatcherFoldDescriptors(element: PsiElement): List<FoldingDescriptor> {
     val iter = element.childrenWithLeaves.iterator()
-    var lastLBrace = 0
+    val braces: Stack<Int> = Stack()
     val descriptors = mutableListOf<FoldingDescriptor>()
     while (iter.hasNext()) {
         val it = iter.next()
         if (it.elementType == LpElementTypes.LBRACE) {
-            lastLBrace = it.startOffset
+            braces.push(it.startOffset)
         } else if (it.elementType == LpElementTypes.RBRACE) {
-            descriptors += listOf(FoldingDescriptor(element, TextRange(lastLBrace, element.endOffset)))
+            if (braces.empty()) {
+                // malformed? what to do?
+            } else {
+                descriptors.add(FoldingDescriptor(element, TextRange(braces.pop(), element.endOffset)))
+            }
         }
     }
 

--- a/src/main/kotlin/com/mdrobnak/lalrpop/psi/util/LpPsiFoldUtil.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/psi/util/LpPsiFoldUtil.kt
@@ -1,0 +1,27 @@
+package com.mdrobnak.lalrpop.psi.util
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import com.mdrobnak.lalrpop.psi.LpElementTypes
+import org.rust.lang.core.psi.ext.childrenWithLeaves
+import org.rust.lang.core.psi.ext.endOffset
+import org.rust.lang.core.psi.ext.startOffset
+
+fun depthOneBraceMatcherFoldDescriptors(element: PsiElement, document: Document, quick: Boolean): List<FoldingDescriptor> {
+    val iter = element.childrenWithLeaves.iterator()
+    var lastLBrace = 0
+    val descriptors = mutableListOf<FoldingDescriptor>()
+    while (iter.hasNext()) {
+        val it = iter.next()
+        if (it.elementType == LpElementTypes.LBRACE) {
+            lastLBrace = it.startOffset
+        } else if (it.elementType == LpElementTypes.RBRACE) {
+            descriptors += listOf(FoldingDescriptor(element, TextRange(lastLBrace, element.endOffset)))
+        }
+    }
+
+    return descriptors
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,5 +36,10 @@
         <lang.findUsagesProvider
                 language="LALRPOP"
                 implementationClass="com.mdrobnak.lalrpop.resolve.LpFindUsagesProvider"/>
+
+        <lang.braceMatcher language="LALRPOP" implementationClass="com.mdrobnak.lalrpop.LpBraceMatcher"/>
+        <lang.commenter language="LALRPOP" implementationClass="com.mdrobnak.lalrpop.LpCommenter"/>
+        <lang.quoteHandler language="LALRPOP" implementationClass="com.mdrobnak.lalrpop.LpQuoteHandler"/>
+        <lang.foldingBuilder language="LALRPOP" implementationClass="com.mdrobnak.lalrpop.LpFoldingBuilder"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Because they somehow were missing and I consider them essential.