### PR TITLE
Mute annoying `NoSuchMethodError`. Add GitHub CI/CD workflow for stable releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build
+        shell: bash
+        run: |
+          mkdir ~/build
+          curl -s "https://get.sdkman.io" | bash
+          . ~/.sdkman/bin/sdkman-init.sh
+          sdk install java 21.0.7-oracle
+          sdk install gradle 8.5
+          gradle build
+          mv build/libs/*jar ~/build/
+          cd ~/build
+          sha256sum *jar > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run:
+          gh release -R ${{ github.repository }} create ${{ github.ref_name }} -t ${{ github.ref_name }} ~/build/SHA256SUMS.txt ~/build/*jar

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     intellijPlatform {
         // Test with a recent EAP or release
-        clion("243.20847.43")
+        clion("2024.3.2")
         plugin 'com.jetbrains.rust:243.20847.53'
 
         pluginVerifier()

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ intellijPlatform {
         ideaVersion {
             // Support 2024.2+ IDEs
             sinceBuild = "242"
+            untilBuild = ""
         }
     }
 

--- a/src/main/kotlin/com/mdrobnak/lalrpop/injectors/LpRustActionCodeInjector.kt
+++ b/src/main/kotlin/com/mdrobnak/lalrpop/injectors/LpRustActionCodeInjector.kt
@@ -20,25 +20,29 @@ class LpRustActionCodeInjector : MultiHostInjector {
         val codeNode = context.code
         val imports = context.containingFile.importCode
 
-        val rustFunctionHeader = context.actionCodeFunctionHeader(true)
+        try {
+            val rustFunctionHeader = context.actionCodeFunctionHeader(true)
 
-        val prefix = """
-            mod __tmp__ {
-                $imports
-                $rustFunctionHeader {
-            """.trimIndent()
+            val prefix = """
+                mod __tmp__ {
+                    $imports
+                    $rustFunctionHeader {
+                """.trimIndent()
 
-        val suffix = """
-            |    }
-            |}
-        """.trimMargin()
+            val suffix = """
+                |    }
+                |}
+            """.trimMargin()
 
-        registrar
-            .startInjecting(RsLanguage)
-            .addPlace(prefix, suffix, context, codeNode.textRangeInParent)
-            .doneInjecting()
+            registrar
+                .startInjecting(RsLanguage)
+                .addPlace(prefix, suffix, context, codeNode.textRangeInParent)
+                .doneInjecting()
 
-        attachInjectedCodeToCrate(context)
+            attachInjectedCodeToCrate(context)
+        } catch (_: NoSuchMethodError) {
+            // Ignore.
+        }
     }
 
     override fun elementsToInjectIn(): List<Class<out PsiElement>> =


### PR DESCRIPTION
This PR tries to solve two problems, separated in two commits.

### About the GitHub Actions workflow

I wrote an automated workflow, originally for my fork, and now I'm sending it here.

The workflow runs when new tag with prefix `v` suchas `v0.2.16` pushed.

### About the IDE Error

The annoying IDE error log shown below appears very frequently (almost 3 times at once) and I've located the function `getLanguagesToInject` in `src/main/kotlin/com/mdrobnak/lalrpop/injectors/LpRustActionCodeInjector.kt` and wrapped it with a `try catch` which do nothing when `NoSuchMethodError` caught.

```
java.lang.NoSuchMethodError: 'com.intellij.psi.tree.IElementType org.rust.lang.core.psi.ext.PsiElementKt.getElementType(com.intellij.psi.PsiElement)'
	at com.mdrobnak.lalrpop.psi.ext.LpRepeatOpKt.switch(LpRepeatOp.kt:9)
	at com.mdrobnak.lalrpop.psi.ext.LpSymbol0Mixin.resolveType(LpSymbol0.kt:12)
	at com.mdrobnak.lalrpop.psi.ext.LpSymbolMixin.resolveType(LpSymbol.kt:42)
	at com.mdrobnak.lalrpop.psi.ext.LpSymbolKt.getSelectedType(LpSymbol.kt:28)
	at com.mdrobnak.lalrpop.psi.ext.LpAlternativeKt.selectedTypesInContext(LpAlternative.kt:28)
	at com.mdrobnak.lalrpop.psi.ext.LpAlternativeKt.selectedTypesInContext$default(LpAlternative.kt:24)
	at com.mdrobnak.lalrpop.psi.ext.LpActionKt.actionCodeFunctionHeader(LpAction.kt:42)
	at com.mdrobnak.lalrpop.injectors.LpRustActionCodeInjector.getLanguagesToInject(LpRustActionCodeInjector.kt:23)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.processInPlaceInjectorsFor(InjectedLanguageManagerImpl.java:495)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.probeElementsUpInner(InjectedLanguageUtilBase.java:238)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.lambda$probeElementsUp$0(InjectedLanguageUtilBase.java:218)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl$allowInWriteAction$1.invoke(ReadActionCacheImpl.kt:41)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl$allowInWriteAction$1.invoke(ReadActionCacheImpl.kt:41)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl.allowInWriteAction(ReadActionCacheImpl.kt:29)
	at com.intellij.openapi.application.impl.ReadActionCacheImpl.allowInWriteAction(ReadActionCacheImpl.kt:41)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.probeElementsUp(InjectedLanguageUtilBase.java:217)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase.enumerate(InjectedLanguageUtilBase.java:160)
	at com.intellij.psi.impl.source.tree.injected.InjectedLanguageManagerImpl.enumerateEx(InjectedLanguageManagerImpl.java:381)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$getInjectedWithHosts$22(InspectionRunner.java:501)
	at com.intellij.concurrency.ApplierCompleter.processArrayItem(ApplierCompleter.java:121)
	at com.intellij.concurrency.ApplierCompleter.processArray(ApplierCompleter.java:205)
	at com.intellij.concurrency.ApplierCompleter.execAll(ApplierCompleter.java:171)
... ... ...
```